### PR TITLE
Night/Dark mode support for Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Multiplatform:
 │       ├── images
 │       │   ├── vector_image.svg
 │       │   └── raster_image.png
+│       ├── images-night
+│       │   ├── vector_image.svg
+│       │   └── raster_image.png
 │       └── strings
 │           ├── strings_en.xml
 │           └── strings_ru.xml
@@ -72,6 +75,9 @@ Android or JVM:
 │   ├── java
 │   └── libres
 │       ├── images
+│       │   ├── vector_image.svg
+│       │   └── raster_image.png
+│       ├── images-night
 │       │   ├── vector_image.svg
 │       │   └── raster_image.png
 │       └── strings
@@ -170,6 +176,15 @@ To obtain bundle of png images with different resolutions (e.g. mdpi - xxxhdpi o
 Sample:
 Image size in Figma is **240x89**. Final image name is **pic_(orig)_(240).png**
 </details>
+
+#### Night/Dark Mode Images
+Night/Dark Mode images are supported for Android and iOS by placing a night version of the image into the 
+`libres/images-night/` folder.
+
+The filename and type of the image must match the corresponding day/light version in `libres/images/`.
+
+- For Android this creates night images in `drawable-night-nodpi`.
+- For iOS this creates a `"appearances" : [ { "appearance" : "luminosity",  "value" : "dark" } ]` entry in the `imageset`.
 
 ## Jetpack Compose
 

--- a/gradle-plugin/src/main/java/io/github/skeptick/libres/plugin/ResourcesPlugin.kt
+++ b/gradle-plugin/src/main/java/io/github/skeptick/libres/plugin/ResourcesPlugin.kt
@@ -118,6 +118,7 @@ class ResourcesPlugin : Plugin<Project> {
     private fun Project.registerGeneratorsTasks() {
         val stringsInputDirectory = File(inputDirectory, "strings")
         val imagesInputDirectory = File(inputDirectory, "images")
+        val nightImagesInputDirectory = File(inputDirectory, "images-night")
         val stringsOutputPackageName = listOfNotNull(outputPackageName, "strings").joinToString(".")
         val imagesOutputPackageName = listOfNotNull(outputPackageName, "images").joinToString(".")
 
@@ -147,6 +148,11 @@ class ResourcesPlugin : Plugin<Project> {
                 appleBundleName = project.appleBundleName
             )
             task.inputDirectory = fileTree(imagesInputDirectory) { config ->
+                config.include { element ->
+                    !element.isDirectory && element.file.extension.lowercase() in IMAGES_EXTENSIONS
+                }
+            }
+            task.nightInputDirectory = fileTree(nightImagesInputDirectory) { config ->
                 config.include { element ->
                     !element.isDirectory && element.file.extension.lowercase() in IMAGES_EXTENSIONS
                 }
@@ -248,5 +254,4 @@ class ResourcesPlugin : Plugin<Project> {
             File(absolutePath, packageName.replace('.', File.separatorChar))
 
     }
-
 }

--- a/gradle-plugin/src/main/java/io/github/skeptick/libres/plugin/images/models/ImageProps.kt
+++ b/gradle-plugin/src/main/java/io/github/skeptick/libres/plugin/images/models/ImageProps.kt
@@ -8,20 +8,23 @@ internal class ImageProps(val file: File) {
     val extension: String
     val targetSize: Int?
     val isTintable: Boolean
+    val isNightMode: Boolean
 
     init {
+        val directoryName = file.parentFile.name
         val nameWithoutExtension = file.nameWithoutExtension
         val parameters = ParametersRegex.findAll(nameWithoutExtension).toList()
+
         this.name = nameWithoutExtension.substringBefore("_(").lowercase()
         this.extension = file.extension.lowercase()
-        this.targetSize = if (extension != "svg") parameters.firstNotNullOfOrNull { it.groupValues[1].toIntOrNull() } else null
+        this.targetSize = if (!isVector) parameters.firstNotNullOfOrNull { it.groupValues[1].toIntOrNull() } else null
         this.isTintable = parameters.none { it.groupValues[1].startsWith("orig") }
+        this.isNightMode = directoryName.endsWith("-night")
     }
 
     companion object {
         private val ParametersRegex = Regex("_\\((.*?)\\)")
     }
-
 }
 
 internal val ImageProps.isVector: Boolean get() = extension == "svg"

--- a/gradle-plugin/src/main/java/io/github/skeptick/libres/plugin/images/models/ImageSet.kt
+++ b/gradle-plugin/src/main/java/io/github/skeptick/libres/plugin/images/models/ImageSet.kt
@@ -1,0 +1,12 @@
+package io.github.skeptick.libres.plugin.images.models
+
+internal class ImageSet(
+    val name: String,
+    val images: Iterable<ImageProps>,
+) {
+    val isVector: Boolean
+        get() = images.all { it.isVector }
+
+    val isTintable: Boolean
+        get() = images.all { it.isTintable }
+}

--- a/gradle-plugin/src/main/java/io/github/skeptick/libres/plugin/images/models/ImageSetContents.kt
+++ b/gradle-plugin/src/main/java/io/github/skeptick/libres/plugin/images/models/ImageSetContents.kt
@@ -23,8 +23,23 @@ internal data class ImageSetContents(
     data class Image(
         val filename: String,
         val scale: ImageScale? = null,
-        val idiom: String = "universal"
+        val idiom: String = "universal",
+        val appearances: List<Appearance>? = null,
     )
+
+    sealed interface Appearance {
+        val appearance: String
+        val value: String
+
+        sealed interface Luminosity : Appearance {
+            override val appearance: String
+                get() = "luminosity"
+
+            object Dark : Luminosity {
+                override val value: String = "dark"
+            }
+        }
+    }
 
     data class Info(
         val author: String = "xcode",
@@ -35,24 +50,4 @@ internal data class ImageSetContents(
         @JsonProperty("preserves-vector-representation") val preserveVectorRepresentation: Boolean?,
         @JsonProperty("template-rendering-intent") val templateRenderingIntent: VectorRenderingType
     )
-
 }
-
-internal fun ImageProps.toImageSetContents() =
-    ImageSetContents(
-        images = when (targetSize) {
-            null -> listOf(
-                ImageSetContents.Image(filename = "$name.$extension")
-            )
-            else -> ImageSetContents.ImageScale.values().map {
-                ImageSetContents.Image(filename = "${this.name}_${it.name}.$extension", scale = it)
-            }
-        },
-        properties = ImageSetContents.Properties(
-            preserveVectorRepresentation = if (isVector) true else null,
-            templateRenderingIntent = when (isTintable) {
-                true -> ImageSetContents.VectorRenderingType.Template
-                false -> ImageSetContents.VectorRenderingType.Original
-            }
-        )
-    )


### PR DESCRIPTION
#### Night/Dark Mode Images
Night/Dark Mode images are supported for Android and iOS by placing a night version of the image into the 
`libres/images-night/` folder.

The filename and type of the image must match the corresponding day/light version in `libres/images/`.

- For Android this creates night images in `drawable-night-nodpi`.
- For iOS this creates a `"appearances" : [ { "appearance" : "luminosity",  "value" : "dark" } ]` entry in the `imageset`.

Closes #24