### PR TITLE
Fall back to English plural rules instead of crashing on unknown locale

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -44,6 +44,8 @@ in JVM 3rd-party library is used. But in Apple this API is closed and in JS it's
 so to avoid burdening the library with heavy solutions, "out of the box" only rules are provided
 for [some languages](../libres-core/src/appleAndJsMain/kotlin/io/github/skeptick/libres/strings/PluralRules.kt).
 
+If there are no rules provided for a language, the library falls back to the English rules.
+
 You can create a Pull Request with the required languages or define these values at runtime:
 
 ```kotlin

--- a/libres-core/src/appleAndJsMain/kotlin/io/github/skeptick/libres/strings/PluralRules.kt
+++ b/libres-core/src/appleAndJsMain/kotlin/io/github/skeptick/libres/strings/PluralRules.kt
@@ -73,7 +73,7 @@ object PluralRules {
             "uk" -> Ukrainian
             "kk" -> Kazakh
             "fr" -> French
-            else -> custom[languageCode] ?: error("Plural rule for '$languageCode' not provided")
+            else -> custom[languageCode] ?: English
         }
     }
 


### PR DESCRIPTION
Currently the library crashes on JS when using any language that doesn't have a set of `PluralRules`. See #53.

They should be added when needed, but I suggest not crashing on it. It's better to fall back to the English formatting rule. For many languages this will already be correct and the ones that need something else should get a custom configuration.

I would like to add some logging still when the fallback is triggered, but there's no logging mechanism in Libres currently so that's omitted.